### PR TITLE
Add source code for @vitest-codemod/types

### DIFF
--- a/.changeset/dry-trees-brush.md
+++ b/.changeset/dry-trees-brush.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/types": patch
+---
+
+Add source code for @vitest-codemod/types

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,5 @@
+# @vitest-codemod/types
+
+> An internal package
+
+This package provides types for vitest-codemod transforms

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@vitest-codemod/types",
+  "version": "0.0.0",
+  "description": "Types for vitest-codemod tranforms",
+  "keywords": [
+    "jscodeshift",
+    "testing",
+    "codemod",
+    "jest",
+    "vitest",
+    "migration"
+  ],
+  "homepage": "https://github.com/trivikr/vitest-codemod/tree/main/packages/types",
+  "license": "MIT",
+  "author": "Kamat, Trivikram <trivikr.dev@gmail.com>",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trivikr/vitest-codemod.git",
+    "directory": "packages/types"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "~4.9.4"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./transform";

--- a/packages/types/src/transform.ts
+++ b/packages/types/src/transform.ts
@@ -1,0 +1,26 @@
+export type PositionalOptionsType = "boolean" | "number" | "string";
+
+export interface VitestCodemodTransformOption {
+  /** array of values, limit valid option arguments to a predefined set */
+  choices?: readonly boolean[] | readonly number[] | readonly string[];
+
+  /** value, set a default value for the option */
+  default?: boolean | number | string;
+
+  /** string, the option description for help content */
+  description: string;
+
+  /** string, the type of the option */
+  type: PositionalOptionsType;
+}
+
+export interface VitestCodemodTransform {
+  /** string, the name of the transform */
+  name: string;
+
+  /** string, the description of the transform for help content */
+  description: string;
+
+  /** array of TransformOption, the which can be passed to the transform */
+  options?: VitestCodemodTransformOption[];
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "resolveJsonModule": true,
+    "rootDir": "src"
+  },
+  "exclude": ["dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,6 +898,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@vitest-codemod/types@workspace:packages/types":
+  version: 0.0.0-use.local
+  resolution: "@vitest-codemod/types@workspace:packages/types"
+  dependencies:
+    typescript: ~4.9.4
+  languageName: unknown
+  linkType: soft
+
 "ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"


### PR DESCRIPTION
Adds source code for @vitest-codemod/types
This would replace the types in transforms folder in vitest-codemod