### PR TITLE
Revert "Version Packages (#9)"

### DIFF
--- a/.changeset/dry-trees-brush.md
+++ b/.changeset/dry-trees-brush.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/types": patch
+---
+
+Add source code for @vitest-codemod/types

--- a/.changeset/fair-pants-travel.md
+++ b/.changeset/fair-pants-travel.md
@@ -1,0 +1,5 @@
+---
+"vitest-codemod": patch
+---
+
+Use types from @vitest-codemod/types

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @vitest-codemod/types
-
-## 0.0.1
-
-### Patch Changes
-
-- [#8](https://github.com/trivikr/vitest-codemod/pull/8) [`8dbfa21`](https://github.com/trivikr/vitest-codemod/commit/8dbfa218adf6ff042cb25928341781d2a79448fd) Thanks [@trivikr](https://github.com/trivikr)! - Add source code for @vitest-codemod/types

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vitest-codemod/types",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Types for vitest-codemod tranforms",
   "keywords": [
     "jscodeshift",

--- a/packages/vitest-codemod/CHANGELOG.md
+++ b/packages/vitest-codemod/CHANGELOG.md
@@ -1,11 +1,5 @@
 # vitest-codemod
 
-## 0.0.3
-
-### Patch Changes
-
-- [#10](https://github.com/trivikr/vitest-codemod/pull/10) [`36886bf`](https://github.com/trivikr/vitest-codemod/commit/36886bf3537d05fd0af47a1c5cd4e75e343588e6) Thanks [@trivikr](https://github.com/trivikr)! - Use types from @vitest-codemod/types
-
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/vitest-codemod/package.json
+++ b/packages/vitest-codemod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-codemod",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "description": "Codemod scripts to migrate your JavaScript unit tests to vitest",
   "keywords": [
     "jscodeshift",
@@ -32,7 +32,7 @@
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
-    "@vitest-codemod/types": "workspace:^0.0.1",
+    "@vitest-codemod/types": "workspace:^0.0.0",
     "typescript": "~4.9.4"
   },
   "engines": {


### PR DESCRIPTION
This reverts commit 95b3e725661ad276f170cbf838b56200aea9b007.

### Issue

Yarn lockfile is not updated, resulting in release failure in https://github.com/trivikr/vitest-codemod/actions/runs/4039762104/jobs/6944796438

### Description

Revert "Version Packages (#9)"

### Testing

CI