### PR TITLE
Run yarn after changeset version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          version: yarn version
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
     "build": "yarn workspaces foreach run build",
-    "release": "yarn build && changeset publish"
+    "release": "yarn build && changeset publish",
+    "version": "changeset version && yarn"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",


### PR DESCRIPTION
### Issue

Refs: https://github.com/changesets/action/issues/170#issuecomment-1092270826

### Description

Runs yarn after changeset version, so that lockfile can be updated

### Testing

Will verify after publish that lockfile gets updated in https://github.com/trivikr/vitest-codemod/pull/16