### PR TITLE
Follow topological-dev order when building packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
-    "build": "yarn workspaces foreach run build",
+    "build": "yarn workspaces foreach --topological-dev run build",
     "release": "yarn build && changeset publish",
     "version": "changeset version && yarn --no-immutable"
   },


### PR DESCRIPTION
### Issue

Noticed in CI failures in https://github.com/trivikr/vitest-codemod/pull/19

### Description

Follow toplogical-dev order when building packages.
This way, the devDependency `@vitest-codemod/types` will be built prior to module `@vitest-codemo/jest`

### Testing

CI