### PR TITLE
chore(codemod): display help from @vitest-codemod/jest

### DIFF
--- a/.changeset/five-adults-report.md
+++ b/.changeset/five-adults-report.md
@@ -1,0 +1,5 @@
+---
+"vitest-codemod": patch
+---
+
+Display name and description from @vitest-codemod/jest

--- a/packages/vitest-codemod/package.json
+++ b/packages/vitest-codemod/package.json
@@ -29,6 +29,7 @@
     "build": "tsc"
   },
   "dependencies": {
+    "@vitest-codemod/jest": "workspace:^0.0.0",
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {

--- a/packages/vitest-codemod/src/utils/getTransforms.ts
+++ b/packages/vitest-codemod/src/utils/getTransforms.ts
@@ -1,4 +1,3 @@
-// import { VitestCodemodTransform } from "@vitest-codemod/types";
+import { transform as jestTransform } from "@vitest-codemod/jest";
 
-// ToDo: Return transforms from @vitest-codemod/* packages
-export const getTransforms = () => [];
+export const getTransforms = () => [jestTransform];

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,7 +908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest-codemod/jest@workspace:packages/jest":
+"@vitest-codemod/jest@workspace:^0.0.0, @vitest-codemod/jest@workspace:packages/jest":
   version: 0.0.0-use.local
   resolution: "@vitest-codemod/jest@workspace:packages/jest"
   dependencies:
@@ -3347,6 +3347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vitest-codemod@workspace:packages/vitest-codemod"
   dependencies:
+    "@vitest-codemod/jest": "workspace:^0.0.0"
     "@vitest-codemod/types": "workspace:^0.0.1"
     jscodeshift: 0.14.0
     typescript: ~4.9.4


### PR DESCRIPTION
### Issue

N/A

### Description

Display help from @vitest-codemod/jest

### Testing

```console
$ ./bin/vitest-codemod --help | head
-----------------------------------------------------------------------------------------------
vitest-codemod is a lightweight wrapper over jscodeshift.
It processes --help, --version and --transform options before passing them downstream.

You can provide names of the custom transforms instead of a local path or url:

         jest  Converts Jest APIs in a Javascript/TypeScript codebase to Vitest 

Example: vitest-codemod -t jest example.spec.js
```