### PR TITLE
Remove "workspace:" protocol for internal dependencies

### DIFF
--- a/.changeset/modern-tigers-repeat.md
+++ b/.changeset/modern-tigers-repeat.md
@@ -1,0 +1,6 @@
+---
+"vitest-codemod": patch
+"@vitest-codemod/jest": patch
+---
+
+Remove "workspace:" protocol for internal dependencies

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -22,7 +22,7 @@
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
-    "@vitest-codemod/types": "workspace:^0.0.2",
+    "@vitest-codemod/types": "^0.0.2",
     "typescript": "~4.9.4"
   },
   "engines": {

--- a/packages/vitest-codemod/package.json
+++ b/packages/vitest-codemod/package.json
@@ -29,11 +29,11 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@vitest-codemod/jest": "workspace:^0.0.1",
+    "@vitest-codemod/jest": "^0.0.1",
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
-    "@vitest-codemod/types": "workspace:^0.0.2",
+    "@vitest-codemod/types": "^0.0.2",
     "typescript": "~4.9.4"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,11 +908,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest-codemod/jest@workspace:^0.0.1, @vitest-codemod/jest@workspace:packages/jest":
+"@vitest-codemod/jest@^0.0.1, @vitest-codemod/jest@workspace:packages/jest":
   version: 0.0.0-use.local
   resolution: "@vitest-codemod/jest@workspace:packages/jest"
   dependencies:
-    "@vitest-codemod/types": "workspace:^0.0.2"
+    "@vitest-codemod/types": ^0.0.2
     jscodeshift: 0.14.0
     typescript: ~4.9.4
   languageName: unknown
@@ -930,7 +930,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vitest-codemod/types@workspace:^0.0.2, @vitest-codemod/types@workspace:packages/types":
+"@vitest-codemod/types@^0.0.2, @vitest-codemod/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@vitest-codemod/types@workspace:packages/types"
   dependencies:
@@ -3347,8 +3347,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "vitest-codemod@workspace:packages/vitest-codemod"
   dependencies:
-    "@vitest-codemod/jest": "workspace:^0.0.1"
-    "@vitest-codemod/types": "workspace:^0.0.2"
+    "@vitest-codemod/jest": ^0.0.1
+    "@vitest-codemod/types": ^0.0.2
     jscodeshift: 0.14.0
     typescript: ~4.9.4
   bin:


### PR DESCRIPTION
### Issue

Workspace protocol is not supported by changesets/action:
* https://github.com/changesets/action/issues/95
* https://github.com/changesets/action/issues/172
* https://github.com/changesets/action/issues/246

This results in following error thrown:
```console
$ npx vitest-codemod@0.0.4 --version

npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:^0.0.1
```

### Description

Remove "workspace:" protocol for internal dependencies

### Testing

Will be verified after publish