### PR TITLE
Return updated transform file path

### DIFF
--- a/.changeset/modern-pillows-leave.md
+++ b/.changeset/modern-pillows-leave.md
@@ -1,0 +1,5 @@
+---
+"vitest-codemod": patch
+---
+
+Return updated transform file path

--- a/packages/vitest-codemod/src/utils/getUpdatedTransformFile.ts
+++ b/packages/vitest-codemod/src/utils/getUpdatedTransformFile.ts
@@ -1,4 +1,2 @@
-import { resolve } from "path";
-
-export const getUpdatedTransformFile = (transformFolder: string) =>
-  resolve(__dirname, "..", "transforms", transformFolder, "transformer.js");
+export const getUpdatedTransformFile = (transformName: string) =>
+  require.resolve(`@vitest-codemod/${transformName}/dist/transformer.js`);


### PR DESCRIPTION
### Issue

N/A

### Description

Returns updated transform file path

### Testing

Verified that filepath was printed on using console.log, and transformation was run

```console
$ ./bin/vitest-codemod -t jest example.js
{
  filePath: '/Users/trivikram/workspace/vitest-codemod/packages/jest/dist/transformer.js'
}
Skipping path example.js which does not exist. 
No files selected, nothing to do. 
All done. 
Results: 
0 errors
0 unmodified
0 skipped
0 ok
```