### PR TITLE
Default parser to babylon

### DIFF
--- a/.changeset/weak-planets-remain.md
+++ b/.changeset/weak-planets-remain.md
@@ -1,0 +1,6 @@
+---
+"vitest-codemod": patch
+"@vitest-codemod/jest": patch
+---
+
+Default parser to babylon

--- a/packages/jest/src/transformer.ts
+++ b/packages/jest/src/transformer.ts
@@ -1,7 +1,7 @@
 import { API, FileInfo } from "jscodeshift";
 
 const transformer = async (file: FileInfo, api: API) => {
-  const j = api.jscodeshift.withParser("babylon");
+  const j = api.jscodeshift;
   const source = j(file.source);
 
   // ToDo: Add the transform logic here

--- a/packages/vitest-codemod/src/utils/getJsCodeshiftParser.ts
+++ b/packages/vitest-codemod/src/utils/getJsCodeshiftParser.ts
@@ -116,7 +116,7 @@ export const getJsCodeshiftParser = () =>
     parser: {
       display_index: 9,
       choices: ["babel", "babylon", "flow", "ts", "tsx"],
-      default: "babel",
+      default: "babylon",
       help: "the parser to use for parsing the source files",
     },
     parserConfig: {


### PR DESCRIPTION
### Issue

Refs:
* https://github.com/facebook/jscodeshift/issues/488
* https://github.com/facebook/jscodeshift/issues/500

### Description

The jscodeshift a parser parameter defaults to `babel5compat`, which is has a significantly reduced feature set from ts, babylon, etc. The upstream project is meaning to switch default parser to babylon.

### Testing

N/A