### PR TITLE
Run global version of tsc from packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@changesets/cli": "^2.26.0",
     "@tsconfig/node14": "^1.0.3",
     "@types/jscodeshift": "^0.11.6",
-    "@types/node": "^14.18.36"
+    "@types/node": "^14.18.36",
+    "typescript": "~4.9.4"
   },
   "packageManager": "yarn@3.3.1",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
     "build": "yarn workspaces foreach --topological-dev run build",
+    "g:tsc": "cd $INIT_CWD && tsc",
     "release": "yarn build && changeset publish",
     "version": "changeset version && yarn --no-immutable"
   },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -22,8 +22,7 @@
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
-    "@vitest-codemod/types": "^0.0.2",
-    "typescript": "~4.9.4"
+    "@vitest-codemod/types": "^0.0.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/jest"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "yarn g:tsc"
   },
   "dependencies": {
     "jscodeshift": "0.14.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,7 @@
     "directory": "packages/types"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "yarn g:tsc"
   },
   "devDependencies": {
     "typescript": "~4.9.4"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,9 +18,6 @@
   "scripts": {
     "build": "yarn g:tsc"
   },
-  "devDependencies": {
-    "typescript": "~4.9.4"
-  },
   "engines": {
     "node": ">=14.0.0"
   }

--- a/packages/vitest-codemod/package.json
+++ b/packages/vitest-codemod/package.json
@@ -26,7 +26,7 @@
     "directory": "packages/vitest-codemod"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "yarn g:tsc"
   },
   "dependencies": {
     "@vitest-codemod/jest": "^0.0.3",

--- a/packages/vitest-codemod/package.json
+++ b/packages/vitest-codemod/package.json
@@ -33,8 +33,7 @@
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
-    "@vitest-codemod/types": "^0.0.2",
-    "typescript": "~4.9.4"
+    "@vitest-codemod/types": "^0.0.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,7 +914,6 @@ __metadata:
   dependencies:
     "@vitest-codemod/types": ^0.0.2
     jscodeshift: 0.14.0
-    typescript: ~4.9.4
   languageName: unknown
   linkType: soft
 
@@ -933,8 +932,6 @@ __metadata:
 "@vitest-codemod/types@^0.0.2, @vitest-codemod/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@vitest-codemod/types@workspace:packages/types"
-  dependencies:
-    typescript: ~4.9.4
   languageName: unknown
   linkType: soft
 
@@ -3280,26 +3277,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.4":
-  version: 4.9.4
-  resolution: "typescript@npm:4.9.4"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e782fb9e0031cb258a80000f6c13530288c6d63f1177ed43f770533fdc15740d271554cdae86701c1dd2c83b082cea808b07e97fd68b38a172a83dbf9e0d0ef9
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@~4.9.4#~builtin<compat/typescript>":
-  version: 4.9.4
-  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 1caaea6cb7f813e64345190fddc4e6c924d0b698ab81189b503763c4a18f7f5501c69362979d36e19c042d89d936443e768a78b0675690b35eb663d19e0eae71
-  languageName: node
-  linkType: hard
-
 "unbox-primitive@npm:^1.0.2":
   version: 1.0.2
   resolution: "unbox-primitive@npm:1.0.2"
@@ -3350,7 +3327,6 @@ __metadata:
     "@vitest-codemod/jest": ^0.0.3
     "@vitest-codemod/types": ^0.0.2
     jscodeshift: 0.14.0
-    typescript: ~4.9.4
   bin:
     vitest-codemod: bin/vitest-codemod
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -926,6 +926,7 @@ __metadata:
     "@tsconfig/node14": ^1.0.3
     "@types/jscodeshift": ^0.11.6
     "@types/node": ^14.18.36
+    typescript: ~4.9.4
   languageName: unknown
   linkType: soft
 
@@ -3274,6 +3275,26 @@ __metadata:
     for-each: ^0.3.3
     is-typed-array: ^1.1.9
   checksum: 2228febc93c7feff142b8c96a58d4a0d7623ecde6c7a24b2b98eb3170e99f7c7eff8c114f9b283085cd59dcd2bd43aadf20e25bba4b034a53c5bb292f71f8956
+  languageName: node
+  linkType: hard
+
+"typescript@npm:~4.9.4":
+  version: 4.9.4
+  resolution: "typescript@npm:4.9.4"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: e782fb9e0031cb258a80000f6c13530288c6d63f1177ed43f770533fdc15740d271554cdae86701c1dd2c83b082cea808b07e97fd68b38a172a83dbf9e0d0ef9
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.9.4#~builtin<compat/typescript>":
+  version: 4.9.4
+  resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 1caaea6cb7f813e64345190fddc4e6c924d0b698ab81189b503763c4a18f7f5501c69362979d36e19c042d89d936443e768a78b0675690b35eb663d19e0eae71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Issue

Refs: https://yarnpkg.com/getting-started/qa#how-to-share-scripts-between-workspaces

### Description

Runs global version of tsc from packages. This way, the typescript dependency needs to be defined only at root level.

### Testing

CI