### PR TITLE
Use getter for adding import declaration

### DIFF
--- a/packages/jest/src/transformer.ts
+++ b/packages/jest/src/transformer.ts
@@ -17,7 +17,7 @@ const transformer = async (file: FileInfo, api: API) => {
     apis.sort()
     const importSpecifiers = apis.map(apiName => j.importSpecifier(j.identifier(apiName)))
     const importDeclaration = j.importDeclaration(importSpecifiers, j.stringLiteral('vitest'))
-    source.get().node.program.body.unshift(importDeclaration)
+    source.get('program', 'body').unshift(importDeclaration)
   }
 
   return source.toSource()


### PR DESCRIPTION
### Issue

Production code in other codemods use getter

Example: https://github.com/deconstructionalism/generator-redux-logic/blob/86bc1abeeb20bf730d2b98d5b3db39c14a12d53a/generators/reducer/index.js#L111

### Description

Use getter for adding import declaration

### Testing

CI