### PR TITLE
Support running tests from *.mjs files

### DIFF
--- a/packages/jest/jest.config.json
+++ b/packages/jest/jest.config.json
@@ -1,3 +1,3 @@
 {
-  "testMatch": ["**/src/__fixtures__/*.input.js"]
+  "testMatch": ["**/src/__fixtures__/*.input.{js,mjs}"]
 }

--- a/packages/jest/src/transformer.spec.ts
+++ b/packages/jest/src/transformer.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'vitest'
 import transform from './transformer'
 
 describe('transformer', () => {
-  const inputFileRegex = /(.*).input.[jt]sx?$/
+  const inputFileRegex = /(.*).input.m?[jt]sx?$/
   const fixtureDir = join(__dirname, '__fixtures__')
 
   const getTestFileMetadata = (dirPath: string) =>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['**/src/__fixtures__/*.output.{js,ts}', '**/*.spec.ts'],
+    include: ['**/src/__fixtures__/*.output.{mjs,js,ts}', '**/*.spec.ts'],
     forceRerunTriggers: ['**/__fixtures__/**'],
   },
 })


### PR DESCRIPTION
### Issue

Requirement was noticed in https://github.com/trivikr/vitest-codemod/pull/49

### Description

Support running tests from `*.mjs` files

### Testing

CI