### PR TITLE
Exclude dist, __fixtures__ and *.spec.ts in root TSConfig

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,5 +2,6 @@
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "declaration": true
-  }
+  },
+  "exclude": ["dist", "**/__fixtures__/**", "**/*.spec.ts"]
 }


### PR DESCRIPTION
### Issue

N/A

### Description

Exclude dist, __fixtures__ and *.spec.ts in root TSConfig

### Testing

Verified that transformer.spec.ts is not compiled by TypeScript