### PR TITLE
Support transformation of `.failing` to `.fails`

### DIFF
--- a/.changeset/orange-pianos-count.md
+++ b/.changeset/orange-pianos-count.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/jest": patch
+---
+
+Support transformation of `.failing` to `.fails`

--- a/packages/jest/src/__fixtures__/test/test-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.input.js
@@ -1,4 +1,8 @@
 describe("test-member", () => {
+  it.failing("Math.sqrt(4) = 3", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
   test.failing("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });

--- a/packages/jest/src/__fixtures__/test/test-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.input.js
@@ -2,8 +2,20 @@ describe("test-member", () => {
   it.failing("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });
+  it.failing.each([
+    [4, 3],
+    [9, 4],
+  ])("Math.sqrt(%s) = %s", (input, output) => {
+    expect(Math.sqrt(input)).toBe(output);
+  });
 
   test.failing("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
+  });
+  test.failing.each([
+    [4, 3],
+    [9, 4],
+  ])("Math.sqrt(%s) = %s", (input, output) => {
+    expect(Math.sqrt(input)).toBe(output);
   });
 });

--- a/packages/jest/src/__fixtures__/test/test-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.input.js
@@ -1,0 +1,5 @@
+describe("test-member", () => {
+  test.failing("Math.sqrt(4) = 3", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/__fixtures__/test/test-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.input.js
@@ -1,4 +1,4 @@
-describe("test-member", () => {
+describe("test-fails", () => {
   it.failing("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, it, test } from "vitest";
 describe("test-member", () => {
+  it.fails("Math.sqrt(4) = 3", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
   test.fails("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-member", () => {
+describe("test-fails", () => {
   it.fails("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -3,8 +3,20 @@ describe("test-member", () => {
   it.fails("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
   });
+  it.fails.each([
+    [4, 3],
+    [9, 4],
+  ])("Math.sqrt(%s) = %s", (input, output) => {
+    expect(Math.sqrt(input)).toBe(output);
+  });
 
   test.fails("Math.sqrt(4) = 3", () => {
     expect(Math.sqrt(4)).toBe(3);
+  });
+  test.fails.each([
+    [4, 3],
+    [9, 4],
+  ])("Math.sqrt(%s) = %s", (input, output) => {
+    expect(Math.sqrt(input)).toBe(output);
   });
 });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -1,0 +1,6 @@
+import { describe, expect, test } from "vitest";
+describe("test-member", () => {
+  test.fails("Math.sqrt(4) = 3", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/__fixtures__/test/test-only-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.input.js
@@ -1,0 +1,17 @@
+describe("test-skip", () => {
+  // This failing test won't be run
+  it("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+  it.only.failing("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
+  // This failing test won't be run
+  test("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+  test.only.failing("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/__fixtures__/test/test-only-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.input.js
@@ -1,4 +1,4 @@
-describe("test-skip", () => {
+describe("test-only-fails", () => {
   // This failing test won't be run
   it("Math.sqrt(4)", () => {
     expect(Math.sqrt(4)).toBe(3);

--- a/packages/jest/src/__fixtures__/test/test-only-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.output.js
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-skip", () => {
+describe("test-only-fails", () => {
   // This failing test won't be run
   it("Math.sqrt(4)", () => {
     expect(Math.sqrt(4)).toBe(3);

--- a/packages/jest/src/__fixtures__/test/test-only-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.output.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, test } from "vitest";
+describe("test-skip", () => {
+  // This failing test won't be run
+  it("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+  it.only.fails("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
+  // This failing test won't be run
+  test("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+  test.only.fails("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/__fixtures__/test/test-skip-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-fails.input.js
@@ -1,0 +1,9 @@
+describe("test-skip-fails", () => {
+  it.skip.failing("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
+  test.skip.failing("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
@@ -1,0 +1,10 @@
+import { describe, expect, it, test } from "vitest";
+describe("test-skip-fails", () => {
+  it.skip.fails("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+
+  test.skip.fails("Math.sqrt(4)", () => {
+    expect(Math.sqrt(4)).toBe(3);
+  });
+});

--- a/packages/jest/src/apis/getApisFromMemberExpression.ts
+++ b/packages/jest/src/apis/getApisFromMemberExpression.ts
@@ -1,6 +1,6 @@
 import type { Collection, Identifier, JSCodeshift } from 'jscodeshift'
 
-const testApiProps = ['concurrent', 'each', 'only', 'skip', 'todo']
+const testApiProps = ['concurrent', 'each', 'only', 'skip', 'todo', 'failing']
 const jestGlobalApiProps = {
   it: testApiProps,
   test: testApiProps,

--- a/packages/jest/src/apis/index.ts
+++ b/packages/jest/src/apis/index.ts
@@ -1,2 +1,3 @@
 export * from './getApisFromCallExpression'
 export * from './getApisFromMemberExpression'
+export * from './replaceTestApiFailing'

--- a/packages/jest/src/apis/replaceTestApiFailing.ts
+++ b/packages/jest/src/apis/replaceTestApiFailing.ts
@@ -1,0 +1,13 @@
+import type { Collection, Identifier, JSCodeshift } from 'jscodeshift'
+
+export const replaceTestApiFailing = (j: JSCodeshift, source: Collection<any>): void => {
+  for (const testApiName of ['it', 'test']) {
+    source.find(j.MemberExpression, {
+      object: { type: 'Identifier', name: testApiName },
+      property: { type: 'Identifier', name: 'failing' },
+    }).forEach((path) => {
+      (path.node.property as Identifier).name = 'fails'
+      return path
+    })
+  }
+}

--- a/packages/jest/src/apis/replaceTestApiFailing.ts
+++ b/packages/jest/src/apis/replaceTestApiFailing.ts
@@ -1,13 +1,31 @@
 import type { Collection, Identifier, JSCodeshift } from 'jscodeshift'
 
+const jestFailsApisName = 'failing'
+const vitestFailsApisName = 'fails'
+
 export const replaceTestApiFailing = (j: JSCodeshift, source: Collection<any>): void => {
   for (const testApiName of ['it', 'test']) {
+    // Replace `(it|test).failing` with `(it|test).fails`
     source.find(j.MemberExpression, {
       object: { type: 'Identifier', name: testApiName },
-      property: { type: 'Identifier', name: 'failing' },
+      property: { type: 'Identifier', name: jestFailsApisName },
     }).forEach((path) => {
-      (path.node.property as Identifier).name = 'fails'
+      (path.node.property as Identifier).name = vitestFailsApisName
       return path
     })
+
+    // Replace `(it|test).(only|skip).failing` with `(it|test).(only|skip).fails`
+    for (const testApiModifierName of ['only', 'skip']) {
+      source.find(j.MemberExpression, {
+        object: {
+          object: { type: 'Identifier', name: testApiName },
+          property: { type: 'Identifier', name: testApiModifierName },
+        },
+        property: { type: 'Identifier', name: jestFailsApisName },
+      }).forEach((path) => {
+        (path.node.property as Identifier).name = vitestFailsApisName
+        return path
+      })
+    }
   }
 }

--- a/packages/jest/src/transformer.ts
+++ b/packages/jest/src/transformer.ts
@@ -1,5 +1,9 @@
 import type { API, FileInfo } from 'jscodeshift'
-import { getApisFromCallExpression, getApisFromMemberExpression } from './apis'
+import {
+  getApisFromCallExpression,
+  getApisFromMemberExpression,
+  replaceTestApiFailing,
+} from './apis'
 
 const transformer = async (file: FileInfo, api: API) => {
   const j = api.jscodeshift
@@ -15,6 +19,8 @@ const transformer = async (file: FileInfo, api: API) => {
     const importDeclaration = j.importDeclaration(importSpecifiers, j.stringLiteral('vitest'))
     source.get('program', 'body').unshift(importDeclaration)
   }
+
+  replaceTestApiFailing(j, source)
 
   source.find(j.ImportDeclaration, { source: { value: '@jest/globals' } }).remove()
 


### PR DESCRIPTION
### Issue

Fixes: https://github.com/trivikr/vitest-codemod/issues/63

### Description

Support transformation of `.failing` to `.fails`

### Testing

CI