### PR TITLE
Removes describe from tests with `it` and `test` APIs

### DIFF
--- a/packages/jest/src/__fixtures__/test/fit-each.input.js
+++ b/packages/jest/src/__fixtures__/test/fit-each.input.js
@@ -1,8 +1,6 @@
-describe("fit-each", () => {
-  fit.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+fit.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/fit-each.output.js
+++ b/packages/jest/src/__fixtures__/test/fit-each.output.js
@@ -1,9 +1,7 @@
-import { describe, expect, it } from "vitest";
-describe("fit-each", () => {
-  it.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+import { expect, it } from "vitest";
+it.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/fit-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/fit-fails.input.js
@@ -1,5 +1,3 @@
-describe("fit-failing", () => {
-  fit.failing("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+fit.failing("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/fit-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/fit-fails.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 it.only.fails("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/fit-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/fit-fails.output.js
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "vitest";
-describe("fit-failing", () => {
-  it.only.fails("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.only.fails("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/fit.input.js
+++ b/packages/jest/src/__fixtures__/test/fit.input.js
@@ -1,5 +1,3 @@
-describe("fit", () => {
-  fit("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+fit("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/fit.output.js
+++ b/packages/jest/src/__fixtures__/test/fit.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 it.only("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/fit.output.js
+++ b/packages/jest/src/__fixtures__/test/fit.output.js
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "vitest";
-describe("fit", () => {
-  it.only("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+it.only("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-each.input.js
@@ -1,15 +1,13 @@
-describe("test-concurrent-each", () => {
-  it.concurrent.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.concurrent.each([
   [4, 2],
   [9, 3],

--- a/packages/jest/src/__fixtures__/test/test-concurrent-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-concurrent-each", () => {
-  it.concurrent.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-only-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-only-each.input.js
@@ -1,15 +1,13 @@
-describe("test-concurrent-only-each", () => {
-  it.concurrent.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-only-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-only-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.concurrent.only.each([
   [4, 2],
   [9, 3],

--- a/packages/jest/src/__fixtures__/test/test-concurrent-only-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-only-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-concurrent-only-each", () => {
-  it.concurrent.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.input.js
@@ -1,15 +1,13 @@
-describe("test-concurrent-skip-each", () => {
-  it.concurrent.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.concurrent.skip.each([
   [4, 3],
   [9, 4],

--- a/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent-skip-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-concurrent-skip-each", () => {
-  it.concurrent.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.concurrent.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.concurrent.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.concurrent.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent.input.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent.input.js
@@ -1,9 +1,7 @@
-describe("test-concurrent", () => {
-  it.concurrent("Math.sqrt()", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+it.concurrent("Math.sqrt()", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});
 
-  test.concurrent("Math.sqrt()", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  })
-})
+test.concurrent("Math.sqrt()", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});

--- a/packages/jest/src/__fixtures__/test/test-concurrent.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.concurrent("Math.sqrt()", () => {
   expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/test-concurrent.output.js
+++ b/packages/jest/src/__fixtures__/test/test-concurrent.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-concurrent", () => {
-  it.concurrent("Math.sqrt()", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+it.concurrent("Math.sqrt()", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});
 
-  test.concurrent("Math.sqrt()", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  })
-})
+test.concurrent("Math.sqrt()", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});

--- a/packages/jest/src/__fixtures__/test/test-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-each.input.js
@@ -1,15 +1,13 @@
-describe("test-each", () => {
-  it.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.each([
   [4, 2],
   [9, 3],

--- a/packages/jest/src/__fixtures__/test/test-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-each", () => {
-  it.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-fails-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails-each.input.js
@@ -1,15 +1,13 @@
-describe("test-fails-each", () => {
-  it.failing.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.failing.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.failing.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.failing.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-fails-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.fails.each([
   [4, 3],
   [9, 4],

--- a/packages/jest/src/__fixtures__/test/test-fails-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-fails-each", () => {
-  it.fails.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.fails.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.fails.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.fails.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.input.js
@@ -1,9 +1,7 @@
-describe("test-fails", () => {
-  it.failing("Math.sqrt(4) = 3", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.failing("Math.sqrt(4) = 3", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.failing("Math.sqrt(4) = 3", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.failing("Math.sqrt(4) = 3", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-fails", () => {
-  it.fails("Math.sqrt(4) = 3", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.fails("Math.sqrt(4) = 3", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.fails("Math.sqrt(4) = 3", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.fails("Math.sqrt(4) = 3", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-fails.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.fails("Math.sqrt(4) = 3", () => {
   expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-only-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-only-each.input.js
@@ -1,15 +1,13 @@
-describe("test-only-each", () => {
-  it.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-only-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-only-each", () => {
-  it.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.only.each([
-    [4, 2],
-    [9, 3],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.only.each([
+  [4, 2],
+  [9, 3],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-only-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.only.each([
   [4, 2],
   [9, 3],

--- a/packages/jest/src/__fixtures__/test/test-only-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.input.js
@@ -1,9 +1,7 @@
-describe("test-only-fails", () => {
-  it.only.failing("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.only.failing("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.only.failing("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.only.failing("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-only-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.only.fails("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-only-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only-fails.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-only-fails", () => {
-  it.only.fails("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.only.fails("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.only.fails("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.only.fails("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-only.input.js
+++ b/packages/jest/src/__fixtures__/test/test-only.input.js
@@ -1,9 +1,7 @@
-describe("test-only", () => {
-  it.only("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+it.only("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});
 
-  test.only("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+test.only("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/test-only.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.only("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/test-only.output.js
+++ b/packages/jest/src/__fixtures__/test/test-only.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-only", () => {
-  it.only("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+it.only("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
+});
 
-  test.only("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(2);
-  });
+test.only("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(2);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip-each.input.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-each.input.js
@@ -1,15 +1,13 @@
-describe("test-skip-each", () => {
-  it.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-each.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.skip.each([
   [4, 3],
   [9, 4],

--- a/packages/jest/src/__fixtures__/test/test-skip-each.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-each.output.js
@@ -1,16 +1,14 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-skip-each", () => {
-  it.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+it.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
+});
 
-  test.skip.each([
-    [4, 3],
-    [9, 4],
-  ])("Math.sqrt(%s) = %s", (input, output) => {
-    expect(Math.sqrt(input)).toBe(output);
-  });
+test.skip.each([
+  [4, 3],
+  [9, 4],
+])("Math.sqrt(%s) = %s", (input, output) => {
+  expect(Math.sqrt(input)).toBe(output);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip-fails.input.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-fails.input.js
@@ -1,9 +1,7 @@
-describe("test-skip-fails", () => {
-  it.skip.failing("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.skip.failing("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.skip.failing("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.skip.failing("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.skip.fails("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip-fails.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-skip-fails", () => {
-  it.skip.fails("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.skip.fails("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.skip.fails("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.skip.fails("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip.input.js
+++ b/packages/jest/src/__fixtures__/test/test-skip.input.js
@@ -1,9 +1,7 @@
-describe("test-skip", () => {
-  it.skip("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.skip("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.skip("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.skip("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip.output.js
@@ -1,10 +1,8 @@
 import { describe, expect, it, test } from "vitest";
-describe("test-skip", () => {
-  it.skip("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+it.skip("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
+});
 
-  test.skip("Math.sqrt(4)", () => {
-    expect(Math.sqrt(4)).toBe(3);
-  });
+test.skip("Math.sqrt(4)", () => {
+  expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-skip.output.js
+++ b/packages/jest/src/__fixtures__/test/test-skip.output.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from "vitest";
+import { expect, it, test } from "vitest";
 it.skip("Math.sqrt(4)", () => {
   expect(Math.sqrt(4)).toBe(3);
 });

--- a/packages/jest/src/__fixtures__/test/test-todo.input.js
+++ b/packages/jest/src/__fixtures__/test/test-todo.input.js
@@ -1,4 +1,2 @@
-describe("test-todo", () => {
-  it.todo("test to be added");
-  test.todo("test to be added");
-});
+it.todo("test to be added");
+test.todo("test to be added");

--- a/packages/jest/src/__fixtures__/test/test-todo.output.js
+++ b/packages/jest/src/__fixtures__/test/test-todo.output.js
@@ -1,5 +1,3 @@
 import { describe, it, test } from "vitest";
-describe("test-todo", () => {
-  it.todo("test to be added");
-  test.todo("test to be added");
-});
+it.todo("test to be added");
+test.todo("test to be added");

--- a/packages/jest/src/__fixtures__/test/test-todo.output.js
+++ b/packages/jest/src/__fixtures__/test/test-todo.output.js
@@ -1,3 +1,3 @@
-import { describe, it, test } from "vitest";
+import { it, test } from "vitest";
 it.todo("test to be added");
 test.todo("test to be added");


### PR DESCRIPTION
### Issue

N/A

### Description

Removes describe from tests with `it` and `test` APIs.
This simplifies the tests, limiting to only things being tested.

### Testing

CI