### PR TITLE
chore(deps-dev): remove vite as vitest has it in-built

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint-staged": "^13.1.0",
     "simple-git-hooks": "^2.8.1",
     "typescript": "~4.9.4",
-    "vite": "^4.0.4",
     "vitest": "^0.28.3"
   },
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,7 +1951,6 @@ __metadata:
     lint-staged: ^13.1.0
     simple-git-hooks: ^2.8.1
     typescript: ~4.9.4
-    vite: ^4.0.4
     vitest: ^0.28.3
   languageName: unknown
   linkType: soft
@@ -7883,7 +7882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^3.0.0 || ^4.0.0, vite@npm:^4.0.4":
+"vite@npm:^3.0.0 || ^4.0.0":
   version: 4.0.4
   resolution: "vite@npm:4.0.4"
   dependencies:


### PR DESCRIPTION
### Issue

N/A

### Description

Vite is not needed to use vitest
https://vitest.dev/guide/#adding-vitest-to-your-project

### Testing

CI