### PR TITLE
Add '@types/jest' devDependency

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -27,6 +27,7 @@
     "jscodeshift": "0.14.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.4.0",
     "@vitest-codemod/types": "^0.0.3",
     "jest": "^29.4.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,6 +1686,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:^29.4.0":
+  version: 29.4.0
+  resolution: "@types/jest@npm:29.4.0"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: 23760282362a252e6690314584d83a47512d4cd61663e957ed3398ecf98195fe931c45606ee2f9def12f8ed7d8aa102d492ec42d26facdaf8b78094a31e6568e
+  languageName: node
+  linkType: hard
+
 "@types/jscodeshift@npm:^0.11.6":
   version: 0.11.6
   resolution: "@types/jscodeshift@npm:0.11.6"
@@ -1929,6 +1939,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@vitest-codemod/jest@workspace:packages/jest"
   dependencies:
+    "@types/jest": ^29.4.0
     "@vitest-codemod/types": ^0.0.3
     jest: ^29.4.1
     jscodeshift: 0.14.0
@@ -3822,7 +3833,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.4.1":
+"expect@npm:^29.0.0, expect@npm:^29.4.1":
   version: 29.4.1
   resolution: "expect@npm:29.4.1"
   dependencies:
@@ -6606,7 +6617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.4.1":
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.4.1":
   version: 29.4.1
   resolution: "pretty-format@npm:29.4.1"
   dependencies:


### PR DESCRIPTION
### Issue

Noticed in https://github.com/trivikr/vitest-codemod/pull/76 that @types/jest are missing

### Description

Add '@types/jest' devDependency

### Testing

CI