### PR TITLE
Preserve file comments when prepending import

### DIFF
--- a/.changeset/late-cameras-kiss.md
+++ b/.changeset/late-cameras-kiss.md
@@ -1,5 +1,5 @@
 ---
-"@vitest-codemod/jest": minor
+"@vitest-codemod/jest": patch
 ---
 
 Preserve file comments when adding imports

--- a/.changeset/late-cameras-kiss.md
+++ b/.changeset/late-cameras-kiss.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/jest": minor
+---
+
+Preserve file comments when adding imports

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    assert(Math.sqrt(4) === 2);
+    assert(Math.sqrt(144) === 12);
+    assert(Math.sqrt(2) === Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ * Example comment which should not be replaced.
  */
 import assert from 'node:assert';
 

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.input.mjs
@@ -1,3 +1,6 @@
+/*
+ * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ */
 import assert from 'node:assert';
 
 describe("basic", () => {

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
@@ -1,0 +1,10 @@
+import { describe, test } from "vitest";
+import assert from 'node:assert';
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    assert(Math.sqrt(4) === 2);
+    assert(Math.sqrt(144) === 12);
+    assert(Math.sqrt(2) === Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
@@ -1,4 +1,8 @@
+/*
+ * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ */
 import { describe, test } from "vitest";
+
 import assert from 'node:assert';
 
 describe("basic", () => {

--- a/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
+++ b/packages/jest/src/__fixtures__/misc/with-existing-imports.output.mjs
@@ -1,5 +1,5 @@
 /*
- * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ * Example comment which should not be replaced.
  */
 import { describe, test } from "vitest";
 

--- a/packages/jest/src/__fixtures__/misc/with-file-headers.input.js
+++ b/packages/jest/src/__fixtures__/misc/with-file-headers.input.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ * Example comment which should not be replaced.
  */
 
 describe("basic", () => {

--- a/packages/jest/src/__fixtures__/misc/with-file-headers.input.js
+++ b/packages/jest/src/__fixtures__/misc/with-file-headers.input.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ */
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(Math.sqrt(4)).toBe(2);
+    expect(Math.sqrt(144)).toBe(12);
+    expect(Math.sqrt(2)).toBe(Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-file-headers.output.js
+++ b/packages/jest/src/__fixtures__/misc/with-file-headers.output.js
@@ -1,0 +1,13 @@
+/*
+ * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ */
+
+import { describe, expect, test } from "vitest";
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(Math.sqrt(4)).toBe(2);
+    expect(Math.sqrt(144)).toBe(12);
+    expect(Math.sqrt(2)).toBe(Math.SQRT2);
+  })
+});

--- a/packages/jest/src/__fixtures__/misc/with-file-headers.output.js
+++ b/packages/jest/src/__fixtures__/misc/with-file-headers.output.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 1994 (c) Netscape, Inc. and its affiliates. All Rights Reserved.
+ * Example comment which should not be replaced.
  */
 
 import { describe, expect, test } from "vitest";

--- a/packages/jest/src/__fixtures__/misc/with-top-jsdoc-comment.input.js
+++ b/packages/jest/src/__fixtures__/misc/with-top-jsdoc-comment.input.js
@@ -1,0 +1,16 @@
+/**
+ * Returns the square root of a number.
+ * @param {number} val 
+ * @returns Square root of val
+ */
+function sqrt(val) {
+  return Math.sqrt(val);
+}
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(sqrt(4)).toBe(2);
+    expect(sqrt(144)).toBe(12);
+    expect(sqrt(2)).toBe(Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-top-jsdoc-comment.output.js
+++ b/packages/jest/src/__fixtures__/misc/with-top-jsdoc-comment.output.js
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+/**
+ * Returns the square root of a number.
+ * @param {number} val 
+ * @returns Square root of val
+ */
+function sqrt(val) {
+  return Math.sqrt(val);
+}
+
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(sqrt(4)).toBe(2);
+    expect(sqrt(144)).toBe(12);
+    expect(sqrt(2)).toBe(Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-top-line-comment.input.js
+++ b/packages/jest/src/__fixtures__/misc/with-top-line-comment.input.js
@@ -1,0 +1,8 @@
+// This test is for math operations
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(Math.sqrt(4)).toBe(2);
+    expect(Math.sqrt(144)).toBe(12);
+    expect(Math.sqrt(2)).toBe(Math.SQRT2);
+  })
+})

--- a/packages/jest/src/__fixtures__/misc/with-top-line-comment.output.js
+++ b/packages/jest/src/__fixtures__/misc/with-top-line-comment.output.js
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "vitest";
+// This test is for math operations
+describe("basic", () => {
+  test("Math.sqrt()", () => {
+    expect(Math.sqrt(4)).toBe(2);
+    expect(Math.sqrt(144)).toBe(12);
+    expect(Math.sqrt(2)).toBe(Math.SQRT2);
+  })
+})

--- a/packages/jest/src/modules/index.ts
+++ b/packages/jest/src/modules/index.ts
@@ -1,0 +1,1 @@
+export * from './prependImport'

--- a/packages/jest/src/modules/prependImport.ts
+++ b/packages/jest/src/modules/prependImport.ts
@@ -1,0 +1,32 @@
+import type { Collection, ImportDeclaration, JSCodeshift, Node } from 'jscodeshift'
+
+export const prependImport = (j: JSCodeshift, source: Collection<any>, importDeclaration: ImportDeclaration) => {
+  const existingImports = source.find(j.ImportDeclaration)
+  if (existingImports.length > 0) {
+    const firstImport = existingImports.at(0)
+    const firstImportNode = firstImport.nodes()[0]
+    if (firstImportNode?.comments) {
+      importDeclaration.comments = firstImportNode.comments
+      firstImportNode.comments = null
+    }
+
+    firstImport.insertBefore(importDeclaration)
+    return
+  }
+
+  const firstNode: Node = source.find(j.Program).get('body', 0).node
+  const { comments } = firstNode
+  if (comments?.length) {
+    const comment = comments[0]
+
+    // Only move comments that look like file-level comments. Ignore
+    // line-level and JSDoc-style comments because these probably belong
+    // to the first node, rather than the file.
+    if ((comment.type === 'Block' || comment.type === 'CommentBlock') && !comment.value.startsWith('*')) {
+      importDeclaration.comments = comments
+      firstNode.comments = null
+    }
+  }
+
+  source.get('program', 'body').unshift(importDeclaration)
+}

--- a/packages/jest/src/transformer.ts
+++ b/packages/jest/src/transformer.ts
@@ -1,41 +1,11 @@
-import type { API, Collection, FileInfo, ImportDeclaration, JSCodeshift, Node } from 'jscodeshift'
+import type { API, FileInfo } from 'jscodeshift'
 import {
   getApisFromCallExpression,
   getApisFromMemberExpression,
   replaceTestApiFailing,
   replaceTestApiFit,
 } from './apis'
-
-const prependImport = (j: JSCodeshift, source: Collection<any>, importDeclaration: ImportDeclaration) => {
-  const existingImports = source.find(j.ImportDeclaration)
-  if (existingImports.length > 0) {
-    const firstImport = existingImports.at(0)
-    const firstImportNode = firstImport.nodes()[0]
-    if (firstImportNode?.comments) {
-      importDeclaration.comments = firstImportNode.comments
-      firstImportNode.comments = null
-    }
-
-    firstImport.insertBefore(importDeclaration)
-    return
-  }
-
-  const firstNode: Node = source.find(j.Program).get('body', 0).node
-  const { comments } = firstNode
-  if (comments?.length) {
-    const comment = comments[0]
-
-    // Only move comments that look like file-level comments. Ignore
-    // line-level and JSDoc-style comments because these probably belong
-    // to the first node, rather than the file.
-    if ((comment.type === 'Block' || comment.type === 'CommentBlock') && !comment.value.startsWith('*')) {
-      importDeclaration.comments = comments
-      firstNode.comments = null
-    }
-  }
-
-  source.get('program', 'body').unshift(importDeclaration)
-}
+import { prependImport } from './modules'
 
 const transformer = async (file: FileInfo, api: API) => {
   const j = api.jscodeshift

--- a/packages/jest/src/transformer.ts
+++ b/packages/jest/src/transformer.ts
@@ -9,7 +9,14 @@ import {
 const prependImport = (j: JSCodeshift, source: Collection<any>, importDeclaration: ImportDeclaration) => {
   const existingImports = source.find(j.ImportDeclaration)
   if (existingImports.length > 0) {
-    existingImports.at(0).insertBefore(importDeclaration)
+    const firstImport = existingImports.at(0)
+    const firstImportNode = firstImport.nodes()[0]
+    if (firstImportNode?.comments) {
+      importDeclaration.comments = firstImportNode.comments
+      firstImportNode.comments = null
+    }
+
+    firstImport.insertBefore(importDeclaration)
     return
   }
 


### PR DESCRIPTION
### Description

Previously, `vitest` imports would get prepended to the very top of the file regardless of whether there was a file-level header, which meant the import would often appear above the comment. This makes two changes:

1. If there are existing imports, move the comment node attached to the first import (if any) to the new, prepended import
2. If there are no existing imports, move the first comment to the inserted import if it looks like a file-level comment (not a line comment, not a JSDoc comment)

### Testing

Added test fixtures

### Additional context

Thanks for building this repo!
