### PR TITLE
Uncomment test for toHaveProperty with number in keyPath array

### DIFF
--- a/packages/jest/src/__fixtures__/expect/toHaveProperty.input.js
+++ b/packages/jest/src/__fixtures__/expect/toHaveProperty.input.js
@@ -44,8 +44,7 @@ test("this house has my desired features", () => {
     ["kitchen", "amenities"],
     ["oven", "stove", "washer"]
   );
-  // Uncomment after https://github.com/vitest-dev/vitest/issues/2804 is fixed
-  // expect(houseForSale).toHaveProperty(["kitchen", "amenities", 0], "oven");
+  expect(houseForSale).toHaveProperty(["kitchen", "amenities", 0], "oven");
   expect(houseForSale).toHaveProperty(
     "livingroom.amenities[0].couch[0][1].dimensions[0]",
     20

--- a/packages/jest/src/__fixtures__/expect/toHaveProperty.output.js
+++ b/packages/jest/src/__fixtures__/expect/toHaveProperty.output.js
@@ -45,8 +45,7 @@ test("this house has my desired features", () => {
     ["kitchen", "amenities"],
     ["oven", "stove", "washer"]
   );
-  // Uncomment after https://github.com/vitest-dev/vitest/issues/2804 is fixed
-  // expect(houseForSale).toHaveProperty(["kitchen", "amenities", 0], "oven");
+  expect(houseForSale).toHaveProperty(["kitchen", "amenities", 0], "oven");
   expect(houseForSale).toHaveProperty(
     "livingroom.amenities[0].couch[0][1].dimensions[0]",
     20


### PR DESCRIPTION
### Issue

Issue https://github.com/vitest-dev/vitest/issues/2804 is fixed, and released in https://github.com/vitest-dev/vitest/releases/tag/v0.28.5

### Description

Uncomment test for toHaveProperty with number in keyPath array

### Testing

CI