### PR TITLE
Delete jest.disableAutomock() as vitest does not mock by default

### DIFF
--- a/.changeset/hot-kiwis-help.md
+++ b/.changeset/hot-kiwis-help.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/jest": patch
+---
+
+Delete jest.disableAutomock() as vitest does not mock by default

--- a/packages/jest/src/__fixtures__/mock/disableAutomock.error.js
+++ b/packages/jest/src/__fixtures__/mock/disableAutomock.error.js
@@ -1,1 +1,0 @@
-jest.disableAutomock();

--- a/packages/jest/src/__fixtures__/mock/disableAutomock.input.js
+++ b/packages/jest/src/__fixtures__/mock/disableAutomock.input.js
@@ -1,0 +1,6 @@
+test("disableAutomock", async () => {
+  jest.disableAutomock();
+
+  const { getToken } = await import("./getToken");
+  expect(getToken()).toBe("token");
+});

--- a/packages/jest/src/__fixtures__/mock/disableAutomock.output.js
+++ b/packages/jest/src/__fixtures__/mock/disableAutomock.output.js
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+test("disableAutomock", async () => {
+  const { getToken } = await import("./getToken");
+  expect(getToken()).toBe("token");
+});

--- a/packages/jest/src/apis/getApisFromMemberExpression.ts
+++ b/packages/jest/src/apis/getApisFromMemberExpression.ts
@@ -8,8 +8,6 @@ const jestGlobalApiProps = {
   test: testApiProps,
 }
 
-const jestApiWithoutProps = ['jest']
-
 const jestToVitestApiMap: Record<string, string> = {
   fit: 'it',
   jest: 'vi',
@@ -33,15 +31,13 @@ export const getApisFromMemberExpression = (j: JSCodeshift, source: Collection<a
     }
   }
 
-  for (const jestApiWithoutProp of jestApiWithoutProps) {
-    const jestApiWithoutPropCalls = source.find(j.MemberExpression, {
-      object: { name: jestApiWithoutProp },
-      property: { type: 'Identifier' },
-    })
+  const jestObjectApiCalls = source.find(j.MemberExpression, {
+    object: { name: 'jest' },
+    property: { type: 'Identifier' },
+  }).filter(path => (path.node.property as Identifier).name !== 'disableAutomock')
 
-    if (jestApiWithoutPropCalls.length)
-      apisFromMemberExpression.push(jestToVitestApiMap[jestApiWithoutProp] ?? jestApiWithoutProp)
-  }
+  if (jestObjectApiCalls.length)
+    apisFromMemberExpression.push('vi')
 
   return apisFromMemberExpression
 }

--- a/packages/jest/src/apis/getApisFromMemberExpression.ts
+++ b/packages/jest/src/apis/getApisFromMemberExpression.ts
@@ -31,13 +31,14 @@ export const getApisFromMemberExpression = (j: JSCodeshift, source: Collection<a
     }
   }
 
+  const jestObjectName = 'jest'
   const jestObjectApiCalls = source.find(j.MemberExpression, {
-    object: { name: 'jest' },
+    object: { name: jestObjectName },
     property: { type: 'Identifier' },
   }).filter(path => (path.node.property as Identifier).name !== 'disableAutomock')
 
   if (jestObjectApiCalls.length)
-    apisFromMemberExpression.push('vi')
+    apisFromMemberExpression.push(jestToVitestApiMap[jestObjectName] ?? jestObjectName)
 
   return apisFromMemberExpression
 }

--- a/packages/jest/src/apis/replaceJestObjectWithVi.ts
+++ b/packages/jest/src/apis/replaceJestObjectWithVi.ts
@@ -1,6 +1,6 @@
 import type { Collection, JSCodeshift } from 'jscodeshift'
 
-const unavailableAutomockApis = ['disableAutomock', 'enableAutomock']
+const unavailableAutomockApis = ['enableAutomock']
 const apiNamesRecord: Record<string, string> = {
   createMockFromModule: 'importMock',
   requireActual: 'importActual',
@@ -22,6 +22,11 @@ export const replaceJestObjectWithVi = (j: JSCodeshift, source: Collection<any>)
           + 'Please switch to explicit mocking in Jest before running transformation, or '
           + 'skip transformation on the files which uses this API.',
         )
+      }
+
+      if (propertyName === 'disableAutomock') {
+        j(path.parentPath).remove()
+        return
       }
 
       if (apiNamesRecord[propertyName])


### PR DESCRIPTION
### Issue

Fixes: https://github.com/trivikr/vitest-codemod/issues/111

### Description

Delete jest.disableAutomock() as vitest does not mock by default

### Testing

CI