### PR TITLE
Add link to migration guide in the error on jest.enableAutomock()

### DIFF
--- a/.changeset/big-geckos-give.md
+++ b/.changeset/big-geckos-give.md
@@ -1,0 +1,5 @@
+---
+"@vitest-codemod/jest": patch
+---
+
+Add link to migration guide in the error on jest.enableAutomock()

--- a/packages/jest/src/apis/replaceJestObjectWithVi.ts
+++ b/packages/jest/src/apis/replaceJestObjectWithVi.ts
@@ -1,6 +1,5 @@
 import type { Collection, JSCodeshift } from 'jscodeshift'
 
-const unavailableAutomockApis = ['enableAutomock']
 const apiNamesRecord: Record<string, string> = {
   createMockFromModule: 'importMock',
   requireActual: 'importActual',
@@ -16,11 +15,12 @@ export const replaceJestObjectWithVi = (j: JSCodeshift, source: Collection<any>)
     if (path.node.property.type === 'Identifier') {
       const propertyName = path.node.property.name
 
-      if (unavailableAutomockApis.includes(propertyName)) {
+      if (propertyName === 'enableAutomock') {
         throw new Error(
-          `The automocking API "${propertyName}" is not supported in vitest.\n\n`
-          + 'Please switch to explicit mocking in Jest before running transformation, or '
-          + 'skip transformation on the files which uses this API.',
+          `The automocking API "${propertyName}" is not supported in vitest.\n`
+          + 'You can explicitly mock using jest.mock in the test file, or '
+          + `skip transformation on the files which use "${propertyName}".\n`
+          + 'See https://vitest.dev/guide/migration.html',
         )
       }
 

--- a/packages/jest/src/apis/replaceJestObjectWithVi.ts
+++ b/packages/jest/src/apis/replaceJestObjectWithVi.ts
@@ -18,8 +18,6 @@ export const replaceJestObjectWithVi = (j: JSCodeshift, source: Collection<any>)
       if (propertyName === 'enableAutomock') {
         throw new Error(
           `The automocking API "${propertyName}" is not supported in vitest.\n`
-          + 'You can explicitly mock using jest.mock in the test file, or '
-          + `skip transformation on the files which use "${propertyName}".\n`
           + 'See https://vitest.dev/guide/migration.html',
         )
       }


### PR DESCRIPTION
### Issue

Follow-up to https://github.com/trivikr/vitest-codemod/issues/111

### Description

Add link to migration guide in the error on jest.enableAutomock()

### Testing

CI