### PR TITLE
Prefix `g:` to global scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
       - run: yarn
-      - run: yarn lint
+      - run: yarn g:lint
       - run: yarn g:build
       - run: yarn g:test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,5 +19,5 @@ jobs:
           cache: "yarn"
       - run: yarn
       - run: yarn lint
-      - run: yarn build
+      - run: yarn g:build
       - run: yarn test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
       - run: yarn
       - run: yarn lint
       - run: yarn g:build
-      - run: yarn test
+      - run: yarn g:test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "yarn@3.4.1",
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
-    "build": "yarn workspaces foreach --topological-dev --verbose run build",
+    "g:build": "yarn workspaces foreach --topological-dev --verbose run build",
     "g:tsc": "cd $INIT_CWD && tsc -p tsconfig.build.json",
     "g:vitest": "cd $INIT_CWD && vitest",
     "lint": "eslint 'packages/**/*.{js,ts,json,md}'",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
     "g:build": "yarn workspaces foreach --topological-dev --verbose run build",
+    "g:test": "yarn workspaces foreach --topological-dev --verbose run test",
     "g:tsc": "cd $INIT_CWD && tsc -p tsconfig.build.json",
     "g:vitest": "cd $INIT_CWD && vitest",
     "lint": "eslint 'packages/**/*.{js,ts,json,md}'",
     "release": "yarn build && changeset publish",
-    "test": "yarn workspaces foreach --topological-dev --verbose run test",
     "version": "changeset version && yarn --no-immutable"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "description": "Monorepo for vitest-codemod scripts",
   "scripts": {
     "g:build": "yarn workspaces foreach --topological-dev --verbose run build",
+    "g:lint": "eslint 'packages/**/*.{js,ts,json,md}'",
     "g:test": "yarn workspaces foreach --topological-dev --verbose run test",
     "g:tsc": "cd $INIT_CWD && tsc -p tsconfig.build.json",
     "g:vitest": "cd $INIT_CWD && vitest",
-    "lint": "eslint 'packages/**/*.{js,ts,json,md}'",
     "release": "yarn build && changeset publish",
     "version": "changeset version && yarn --no-immutable"
   },


### PR DESCRIPTION
### Issue

Fixes: https://github.com/trivikr/vitest-codemod/issues/129

### Description

Prefixes `g:` to global scripts, as it's likely causing intermittent CI failures

### Testing

CI