### PR TITLE
Pass verbose flag when running jest tests

### DIFF
--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -2,6 +2,8 @@
 
 > An internal package
 
+test
+
 This package provides a transformer for vitest to jest.
 
 For usage, check [vitest-codemod](https://www.npmjs.com/package/vitest-codemod).

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -2,8 +2,6 @@
 
 > An internal package
 
-test
-
 This package provides a transformer for vitest to jest.
 
 For usage, check [vitest-codemod](https://www.npmjs.com/package/vitest-codemod).

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "yarn g:tsc",
-    "test:jest": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "test:jest": "yarn node --experimental-vm-modules $(yarn bin jest) --verbose",
     "test": "yarn test:jest && yarn g:vitest"
   },
   "dependencies": {


### PR DESCRIPTION
### Issue

Refs: https://github.com/trivikr/vitest-codemod/issues/129

### Description

Pass verbose flag when running jest tests.
This will help surface which jest test fails.

### Testing

CI