### PR TITLE
Run jest tests serially

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "yarn g:tsc",
-    "test:jest": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "test:jest": "yarn node --experimental-vm-modules $(yarn bin jest) --runInBand",
     "test": "yarn test:jest && yarn g:vitest"
   },
   "dependencies": {


### PR DESCRIPTION
### Issue

Fixes: https://github.com/trivikr/vitest-codemod/issues/129

### Description

Run jest tests serially to check if GitHub CI fails

Using `--runInBand` has helped many folks in the past, like https://github.com/facebook/jest/issues/8769#issuecomment-652486175

### Testing

CI