### PR TITLE
chore(scripts): enable npm trusted publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
+          node-version: "24.x" # Trusted publishing requires npm >=v11.5.1
           cache: "yarn"
 
       - run: yarn
@@ -26,4 +27,3 @@ jobs:
           publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Issue

https://docs.npmjs.com/trusted-publishers

### Description

Enables npm trusted publishing

npm package settings has Trusted publisher enabled for `trivikr/vitest-codemod:push.yml` 

### Testing

Will be tested with `v0.5.0`